### PR TITLE
LiriBuild.cmake: add resources param handling to liri_add_module name

### DIFF
--- a/modules/LiriBuild.cmake
+++ b/modules/LiriBuild.cmake
@@ -261,6 +261,12 @@ function(liri_add_module name)
     endif()
     add_library("Liri::${target}" ALIAS "${target}")
 
+    # add resources
+    if(DEFINED _arg_RESOURCES)
+        qt5_add_resources(RESOURCES ${_arg_RESOURCES})
+        list(APPEND _arg_SOURCES ${RESOURCES})
+    endif()
+
     # Add target for the private API
     set(target_private "${target}Private")
     add_library("${target_private}" INTERFACE)


### PR DESCRIPTION
RESOURCES are used at liri eglfs. Without this patch start of liri session
complains:

| liri-shell: symbol lookup-error: /usr/lib/libLiri1EglFSDeviceIntegration.so.1: undefined symbol: _Z21qInitResources_cursorv

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>