### PR TITLE
Change C++ standard to C++14

### DIFF
--- a/modules/LiriSetup.cmake
+++ b/modules/LiriSetup.cmake
@@ -14,7 +14,7 @@ else()
 endif()
 
 ## Force C++ standard, do not fall back, use compiler extensions:
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 


### PR DESCRIPTION
C++14 has introduced several minor improvements and bugfixes over C++11.
It doesn't bring any major new features but makes using features introduced in C++11 less cumbersome in some cases.