### PR TITLE
Upload artifacts to Bintray

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,16 @@ jobs:
           tar czf artifacts/cmake-shared.tar.gz -T install_manifest.txt
       - name: Archive result
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v1
+        uses: liri-infra/github-action-upload-bintray@master
         with:
-          name: artifacts-${{ steps.extract_branch.outputs.branch }}
-          path: build/artifacts/
+          file: build/artifacts/cmake-shared.tar.gz
+          api_user: ${{ secrets.BINTRAY_API_USER }}
+          api_key: ${{ secrets.BINTRAY_API_KEY }}
+          repository_user: liri
+          repository: artifacts-${{ steps.extract_branch.outputs.branch }}
+          package: cmake-shared
+          version: '1.0'
+          delete_file: true
+          recreate_version: true
+          calculate_metadata: false
+          publish: '1'


### PR DESCRIPTION
GitHub artifacts expire after a while and cannot be retrieved anymore.
Upload them to Bintray instead.
