### PR TITLE
use gnuinstalldirs for standard compliance

### DIFF
--- a/modules/LiriBuild.cmake
+++ b/modules/LiriBuild.cmake
@@ -2,21 +2,23 @@
 set(_LIRI_VERSION_HEADER_TEMPLATE "${CMAKE_CURRENT_LIST_DIR}/LiriModuleVersion.h.in")
 set(_LIRI_MODULE_CONFIG_TEMPLATE "${CMAKE_CURRENT_LIST_DIR}/LiriModuleConfig.cmake.in")
 
+include(GNUInstallDirs)
+
 # Install locations:
-set(INSTALL_BINDIR "bin" CACHE PATH "Executables [PREFIX/bin]")
-set(INSTALL_INCLUDEDIR "include" CACHE PATH "Header files [PREFIX/include]")
-set(INSTALL_LIBDIR "lib" CACHE PATH "Libraries [PREFIX/lib]")
+set(INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "Executables [PREFIX/bin]")
+set(INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH "Header files [PREFIX/include]")
+set(INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Libraries [PREFIX/lib]")
 set(INSTALL_PLUGINSDIR "${INSTALL_LIBDIR}/plugins" CACHE PATH
     "Plugins [LIBDIR/plugins]")
-set(INSTALL_LIBEXECDIR "libexec" CACHE PATH "Helper programs [PREFIX/libexec]")
+set(INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}" CACHE PATH "Helper programs [PREFIX/libexec]")
 set(INSTALL_QMLDIR "${INSTALL_LIBDIR}/qml" CACHE PATH "QML2 imports [LIBDIR/qml]")
-set(INSTALL_DATADIR "share" CACHE PATH  "Arch-independent data [PREFIX/share]")
-set(INSTALL_APPLICATIONSDIR "share/applications" CACHE PATH
+set(INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}" CACHE PATH  "Arch-independent data [PREFIX/share]")
+set(INSTALL_APPLICATIONSDIR "${INSTALL_DATADIR}/applications" CACHE PATH
     "Desktop entries [PREFIX/share/applications]")
-set(INSTALL_METAINFODIR "share/metainfo" CACHE PATH
+set(INSTALL_METAINFODIR "${INSTALL_DATADIR}/metainfo" CACHE PATH
     "AppStream metadata [PREFIX/share/metainfo]")
 set(INSTALL_DOCDIR "${INSTALL_DATADIR}/doc" CACHE PATH "Documentation [DATADIR/doc]")
-set(INSTALL_SYSCONFDIR "etc" CACHE PATH "Settings used by Liri programs [PREFIX/etc]")
+set(INSTALL_SYSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}" CACHE PATH "Settings used by Liri programs [PREFIX/etc]")
 
 # Make Qt Creator QML syntax highlighting aware of our modules:
 set(QML_IMPORT_PATH "${CMAKE_INSTALL_PREFIX}/${INSTALL_QMLDIR}" CACHE PATH


### PR DESCRIPTION
Signed-off-by: Aisha Tammy <floss@bsd.ac>

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [x] Do the unit tests pass with this change?
- [ ] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)
N/A

### Description of change
Affects install locations which are not the same as the ones used in the default configuration.
Needed for gentoo linux where libdirs and docdirs are in slightly different places.

