### PR TITLE
Remove useless macros

### DIFF
--- a/modules/LiriAddExecutable.cmake
+++ b/modules/LiriAddExecutable.cmake
@@ -31,13 +31,16 @@ function(liri_add_executable name)
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Core)
 
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_executable"
+    cmake_parse_arguments(
+        _arg
         "GUI;NO_TARGET_INSTALLATION"
         "OUTPUT_NAME;OUTPUT_DIRECTORY;INSTALL_DIRECTORY;DESKTOP_INSTALL_DIRECTORY;QTQUICK_COMPILER"
         "EXE_FLAGS;${__default_private_args};APPDATA;DESKTOP"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_executable (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     if("x${_arg_OUTPUT_NAME}" STREQUAL "x")
         set(_arg_OUTPUT_NAME "${name}")

--- a/modules/LiriAddModule.cmake
+++ b/modules/LiriAddModule.cmake
@@ -25,8 +25,6 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-include(CMakeParseArguments)
-
 set(_fwd_headers_exe "${CMAKE_CURRENT_LIST_DIR}/liri-forward-headers")
 
 function(_liri_internal_forward_headers destination_var)
@@ -123,13 +121,16 @@ function(liri_add_module name)
     include(ECMGeneratePkgConfigFile)
 
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_module"
+    cmake_parse_arguments(
+        _arg
         "NO_MODULE_HEADERS;NO_CMAKE;NO_PKGCONFIG;STATIC"
         "DESCRIPTION;MODULE_NAME;VERSIONED_MODULE_NAME;QTQUICK_COMPILER"
         "${__default_private_args};${__default_public_args};INSTALL_HEADERS;FORWARDING_HEADERS;PRIVATE_HEADERS;PKGCONFIG_DEPENDENCIES"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_module (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     # A 0.x version is going to be 1.x once it's ready, but we don't
     # want to change find_package(Liri0${name}) instructions everywhere
@@ -144,7 +145,7 @@ function(liri_add_module name)
     if(DEFINED _arg_MODULE_NAME)
         set(module "${_arg_MODULE_NAME}")
     else()
-        _liri_module_name("${name}" module)
+        set(module "Liri${name}")
     endif()
     string(TOUPPER "${module}" module_upper)
     string(TOLOWER "${module}" module_lower)

--- a/modules/LiriAddPlugin.cmake
+++ b/modules/LiriAddPlugin.cmake
@@ -30,13 +30,16 @@ function(liri_add_plugin name)
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Core)
 
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_plugin"
+    cmake_parse_arguments(
+        _arg
 	"STATIC"
         "TYPE;QTQUICK_COMPILER"
         "${__default_private_args};${__default_public_args}"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_plugin (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     set(target "${name}")
     string(TOUPPER "${name}" name_upper)

--- a/modules/LiriAddQmlModule.cmake
+++ b/modules/LiriAddQmlModule.cmake
@@ -27,13 +27,16 @@
 
 function(liri_add_qml_module name)
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_qml_module"
+    cmake_parse_arguments(
+        _arg
         ""
         "MODULE_PATH;VERSION"
         "QML_FILES"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_qml_module (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     if(NOT DEFINED _arg_MODULE_PATH)
         message(FATAL_ERROR "Missing argument MODULE_PATH.")

--- a/modules/LiriAddQmlPlugin.cmake
+++ b/modules/LiriAddQmlPlugin.cmake
@@ -30,13 +30,16 @@ function(liri_add_qml_plugin name)
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Qml Quick)
 
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_qml_plugin"
+    cmake_parse_arguments(
+        _arg
 	"STATIC"
         "MODULE_PATH;VERSION;QTQUICK_COMPILER"
         "${__default_private_args};${__default_public_args};QML_FILES"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_qml_plugin (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     if(NOT DEFINED _arg_MODULE_PATH)
         message(FATAL_ERROR "Missing argument MODULE_PATH.")

--- a/modules/LiriAddSettingsModule.cmake
+++ b/modules/LiriAddSettingsModule.cmake
@@ -27,13 +27,16 @@
 
 function(liri_add_settings_module name)
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_settings_module"
+    cmake_parse_arguments(
+        _arg
         ""
         "METADATA;TRANSLATIONS_PATH"
         "CONTENTS"
         ${ARGN}
-        )
+    )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_settings_module (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     # Find packages we need
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Core LinguistTools)

--- a/modules/LiriAddStatusAreaExtension.cmake
+++ b/modules/LiriAddStatusAreaExtension.cmake
@@ -27,13 +27,16 @@
 
 function(liri_add_statusareaextension name)
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_statusareaextension"
+    cmake_parse_arguments(
+        _arg
         ""
         "METADATA;CONTENTS_DIRECTORY;TRANSLATIONS_PATH"
         "QML_FILES"
         ${ARGN}
-        )
+    )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_statusareaextension (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     # Find packages we need
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Core LinguistTools)

--- a/modules/LiriAddTest.cmake
+++ b/modules/LiriAddTest.cmake
@@ -30,13 +30,16 @@ function(liri_add_test name)
     find_package(Qt5 "5.0" CONFIG REQUIRED COMPONENTS Core Test)
 
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_add_test"
+    cmake_parse_arguments(
+        _arg
         "RUN_SERIAL"
         ""
         "${__default_private_args}"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_add_test (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     # Absolute installation paths
     if(IS_ABSOLUTE "${INSTALL_BINDIR}")

--- a/modules/LiriQDoc.cmake
+++ b/modules/LiriQDoc.cmake
@@ -27,13 +27,16 @@
 
 function(liri_install_doc qdoc_filename)
     # Parse arguments
-    _liri_parse_all_arguments(
-        _arg "liri_install_doc"
+    cmake_parse_arguments(
+        _arg
         ""
         "OUTPUT_DIRECTORY_VARIABLE"
         "ENVIRONMENT"
         ${ARGN}
     )
+    if(DEFINED _arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments were passed to liri_install_doc (${_arg_UNPARSED_ARGUMENTS}).")
+    endif()
 
     find_package(Qt5Core QUIET)
     if(TARGET Qt5::qmake)


### PR DESCRIPTION
Just use `cmake_parse_arguments` instead of `_liri_parse_all_arguments`.

Copy the code of `_liri_module_name` inside `liri_add_module` since it's
used only there.

And remove a bunch of macros that we never used.
